### PR TITLE
Accordion effect for showing markup on index page, remove slugify

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const methodOverride = require ('method-override');
 const app = express();
 const port = 5001;
 
-mongoose.connect ('mongodb://localhost/blog'), {
+mongoose.connect ('mongodb://localhost/notes'), {
      useCreateIndex: true
 };
 

--- a/models/article.js
+++ b/models/article.js
@@ -1,6 +1,6 @@
 const mongoose = require ('mongoose');
 const marked = require ('marked');
-const slugify = require ('slugify');
+//const slugify = require ('slugify');
 const createDomPurify = require ('dompurify');
 const { JSDOM } = require ('jsdom');
 const dompurify = createDomPurify (new JSDOM().window);
@@ -21,11 +21,11 @@ const articleSchema = new mongoose.Schema ({
           type: Date,
           default: Date.now
      },
-     slug: {
+/*     slug: {
           type: String,
           required: true,
           unique: true
-     },
+     }, */
      sanitizedHtml: {
           type: String,
           required: true
@@ -33,9 +33,10 @@ const articleSchema = new mongoose.Schema ({
 });
 
 articleSchema.pre ('validate', function (next) {
-     if (this.keywords) {
+/*   if (this.keywords) {
           this.slug = slugify (this.keywords, { lower: true, strict: true });
      };
+*/
 
      if (this.markdown) {
           this.sanitizedHtml = dompurify.sanitize(marked.parse(this.markdown));

--- a/public/css/bootstrap.css
+++ b/public/css/bootstrap.css
@@ -5066,7 +5066,8 @@ fieldset:disabled .btn {
 }
 
 .card-text:last-child {
-     margin-bottom: 0
+     margin-bottom: 0;
+     font-size: larger;
 }
 
 .card-link+.card-link {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -6,11 +6,13 @@ body {
 .code {
      background: #333333;
      margin-top: 20px;
-     font-size: large;
+     font-size: larger;
+     padding: 5px;
+     max-width: 95%;
 }
 
 .container {
-     width: 60%;
+     width: 75%;
      display: grid;
      grid-template-columns: 1fr;
      padding: 20px;
@@ -20,9 +22,15 @@ body {
      height: 100vh;
 }
 .wrapper {
+     width: 100%;
      display: grid;
      grid-template-columns: 1fr;
      margin: auto;
+}
+
+.card {
+     margin: auto;
+     width: 75%;
 }
 
 .show {
@@ -41,7 +49,7 @@ body {
      border: solid 1px #acaba8;
      border-width: 1px;
      margin-bottom: 20px;
-     margin-top: 20px;
+     margin-top: 50px;
 }
 
 .btn-show {
@@ -59,6 +67,21 @@ body {
 
 .dates {
      font-size: small;
+}
+
+.accordion {
+     transition: 0.4s;
+}
+
+.active, .accordion:hover {
+     background-color: #ccc;
+}
+
+.panel {
+     padding: 0 18px;
+     background-color: white;
+     display: none;
+     overflow: hidden;
 }
 
 .lg-txt {

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -17,8 +17,8 @@ router.get ('/edit/:id', async (req, res) => {
      res.render ('articles/edit', { article: article });
 });
 
-router.get ('/:slug', async (req, res) => {
-     const article = await Article.findOne( { slug: req.params.slug });
+router.get ('/:id', async (req, res) => {
+     const article = await Article.findById( req.params.id );
      if (article == null) res.redirect ('/');
      res.render ('articles/show', { article: article });
 });
@@ -46,7 +46,7 @@ function saveArticleAndRedirect(path) {
           article.markdown = req.body.markdown;
           try {
                article = await article.save();
-               res.redirect (`/articles/${article.slug}`)
+               res.redirect (`/articles/${article.id}`);
           } catch (e) {
                console.log (e);
                res.render (`articles/${path}`, { article: article });

--- a/views/articles/index.ejs
+++ b/views/articles/index.ejs
@@ -12,22 +12,82 @@
     <div class="container">
         <h1 class="mb-4">Neat Code Snippets</h1>
         <a href="/articles/new" class="btn btn-success">New Snippet</a>
-
+<div class="wrapper">
         <% articles.forEach(article => { %>
-        <div class="card mt-4">
-            <div class="card-body">
+        <div class="card">
+            <div class="card-body <%= article.id %> ">
                 <h4 class="card-title"> <%= article.keywords %></h4>
                 <div class="card-subtitle text-muted mb-2"><%= article.createdAt.toLocaleDateString() %></div>
                 <div class="card-text mb-2"><%= article.description %></div>
-                <a href="articles/<%= article.slug %>" class="btn btn-primary">Show</a>
+                <button class="accordion btn btn-primary">Show</button>
+                <a href="articles/<%= article.id %>" class="btn btn-info">Direct Link</a>
                 <a href="articles/edit/<%= article.id %>" class="btn btn-info">Edit</a>
                 <form action="/articles/<%= article.id %>?_method=DELETE" method="POST" class="d-inline">
                     <button type="submit" class="btn btn-danger">Delete</button>
                 </form>
+                <div class="panel" id="pnl">
+                    <div class="code">
+                        <%- article.sanitizedHtml %>
+                    </div>
+                </div>
             </div>
         </div>
         <% }) %>
     </div>
+    </div>
+
+    <script>
+        /*
+        This portion gets all elements of the card; code is adapted from:
+        https://www.javascripttutorial.net/javascript-dom/javascript-siblings/
+        */
+
+        let getSiblings = function (e) {
+        // for collecting siblings
+            let siblings = []; 
+            // if no parent, return no sibling
+            if(!e.parentNode) {
+                return siblings;
+            }
+            // first child of the parent node
+            let sibling  = e.parentNode.firstChild;
+            // collecting siblings
+            while (sibling) {
+                if (sibling.nodeType === 1 && sibling !== e) {
+                    siblings.push(sibling);
+                }
+                sibling = sibling.nextSibling;
+            }
+            return siblings;
+        };
+
+        /*
+        This portion creates the accordion effect for displaying markdown; code is adapted from:
+        https://www.w3schools.com/howto/howto_js_accordion.asp
+        */
+
+        var acc = document.getElementsByClassName("accordion");
+        var i;
+
+        for (i = 0; i < acc.length; i++) {
+            acc[i].addEventListener("click", function() {
+                /* Toggle between adding and removing the "active" class,
+                to highlight the button that controls the panel */
+                var panel = getSiblings(this).pop();
+                this.classList.toggle("active");
+                /* Toggle between hiding and showing the active panel */
+//                var panel = this.nextElementSibling;
+                if (panel.style.display === "block") {
+                panel.style.display = "none";
+                acc.innerHTML = "Show";
+                } else {
+                panel.style.display = "block";
+                acc.innerHTML = "Hide";
+                }
+                //if button == show, make hide, vice versa if ()
+            });
+        }
+    </script>
 
 </body>
 </html>

--- a/views/articles/show.ejs
+++ b/views/articles/show.ejs
@@ -28,7 +28,7 @@
     </div>
     <div class="btn-show">
         <div class="btnz">
-            <a href="/" class="btn btn-secondary">All Articles</a>
+            <a href="/" class="btn btn-secondary">All Snippets</a>
         </div>
         <div class="btnz">
             <a href="/articles/edit/<%= article.id %>" class="btn btn-info">Edit</a>


### PR DESCRIPTION
- Remove slugify (snippets don't use titles, and that field was adapted to be `keywords` anyway, which is not unique; readable URLs aren't really necessary for snippets anyway)
- Change wording on site from `articles` to `snippets`
- Add an accordion effect for displaying the markdown directly on the main (`index`) page (rather than linking to them).
  - Required grabbing the correct element (which had to be done programmatically, since all cards on the page will have the same classes)
  - Accomplished by grabbing a list of all elements that are siblings with the button that was clicked, and returning the last one (markdown panel is positioned as the last element).